### PR TITLE
Changed camera class to apply rotations after position

### DIFF
--- a/js/camera.coffee
+++ b/js/camera.coffee
@@ -12,9 +12,9 @@ define ['vector', 'keyboard', 'wheel'], (Vector, Keyboard, Wheel) ->
     scale: 1
 
     update: (deltaTime) ->
-      @_updateRotation(deltaTime)
       @_updateScale(deltaTime)
       @_updatePosition(deltaTime)
+      @_updateRotation(deltaTime)
 
     _updateRotation: (deltaTime) ->
       @rotation += @ROTATE_SPEED * deltaTime if Keyboard.isDown 69


### PR DESCRIPTION
There was a bug with rotation due to rotation being applied before position in the camera class. We moved the rotation update method to occur after position so the camera rotates correctly.
